### PR TITLE
re-establish compatibility of socket.io with python

### DIFF
--- a/MixerControl-app/package.json
+++ b/MixerControl-app/package.json
@@ -42,7 +42,7 @@
     "request": "^2.83.0",
     "rxjs": "5.4.2",
     "serve-favicon": "^2.4.5",
-    "socket.io": "^2.0.3",
+    "socket.io": "^1.7.4",
     "ssl-root-cas": "^1.2.4",
     "websocket": "^1.0.24",
     "winston": "^2.4.0",


### PR DESCRIPTION
changed back to older version of socket.io to re-establish support for python socketio-client