### PR TITLE
accept url anchor coupon codes not only for the iuno.axoom.cloud url

### DIFF
--- a/MixerControl-app/routes/orders.js
+++ b/MixerControl-app/routes/orders.js
@@ -89,8 +89,14 @@ router.put('/:id/payment', function (req, res, next) {
     let data = req.body;
     if (invoice !== undefined) {
         if (data !== undefined) {
-            if (data.startsWith("http://iuno.axoom.cloud/?") || data.startsWith("http://iuno.axoom.cloud/#")) {
+            if (data.startsWith("http://iuno.axoom.cloud/?") { // legacy coupon format
                 data = data.substring(25);
+            }
+            else if (data.includes('#')) { // url anchor coupon format
+                data = data.split('#').pop() // get string after last hash which should be a coupon
+            }
+            else { // raw data is the coupon itself
+                // do nothing
             }
 
             payment_service.redeemCoupon(invoice, data, function (err, paymentResponse, data) {


### PR DESCRIPTION
@blumenet tried to create coupons with a different URL than http://iuno.axoom.cloud/ which were unfortunately not accepted by the MixerControl.

This PR enables the MixerControl to accept URL anchor coupon codes for arbitrary URLs.

Please review carefully since I could not run the MixerControl to test this change.